### PR TITLE
simplify, simplify, simplify

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,5 @@ Please ask another designer/developer to merge your pull request.
 - [ ] Included Jira reference in commit message (if applicable)
 
 # Post-Merge Checklist
-- [ ] Update the `gh-pages` branch with the latest version of `cheatsheet.html`
 - [ ] [Create a new release](https://help.github.com/articles/creating-releases/)
 - [ ] Have a UX designer update the [Frontify styleguide](https://app.frontify.com/d/JC5zNa6KOQ2r/build-com-style-guide#/other/icons)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Build.com Custom Ionicons!</title>
+	</head>
+	<body>
+		<h1>Build Ionicons!</h1>
+		<h2>Resources</h2>
+		<ul>
+			<li><a href="cheatsheet.html">Cheat Sheet</a></li>
+		</ul>
+	</body>
+</html>


### PR DESCRIPTION
Going to switch from `gh-pages` to `master` for the source of documentations